### PR TITLE
Copilot CLI による日次 plan issue 自動起票 workflow を追加

### DIFF
--- a/.github/prompts/daily-plan-issue.prompt.md
+++ b/.github/prompts/daily-plan-issue.prompt.md
@@ -1,0 +1,58 @@
+あなたは GitHub Actions 上で非対話実行される GitHub Copilot CLI です。
+
+目的:
+- このリポジトリの現状を短く要約し、次に進める改善候補を日本語で issue 本文として提案する。
+
+制約:
+- 出力は issue 本文の Markdown のみとする。
+- コードブロック、JSON、前置き、締めの挨拶は出さない。
+- 今日の状況と、次に進める候補 2-3 件、最優先で着手する 1 件を含める。
+- 候補ごとに「目的」「主な変更点」「必要なテスト」「リスク」を短く含める。
+- 既存の open issue と最近の closed issue を見て、重複提案を避ける。
+- secrets や token の値は絶対に書かない。
+- 外部参照は行わず、渡された文脈だけで判断する。
+
+出力フォーマット:
+## 今日の状況
+- 箇条書き 2-4 件
+
+## 次に進める候補
+### 候補1
+- 目的:
+- 主な変更点:
+- 必要なテスト:
+- リスク:
+
+### 候補2
+- 目的:
+- 主な変更点:
+- 必要なテスト:
+- リスク:
+
+### 候補3
+- 目的:
+- 主な変更点:
+- 必要なテスト:
+- リスク:
+
+## 今日の推奨
+- 最初に着手する候補を 1 件だけ選び、理由を 2-3 文で書く。
+
+文脈:
+- 対象日: {{PLAN_DATE}}
+- リポジトリ: {{REPOSITORY}}
+
+README:
+{{README_CONTENT}}
+
+PLAN:
+{{PLAN_CONTENT}}
+
+Copilot Instructions:
+{{COPILOT_INSTRUCTIONS}}
+
+Open Issues:
+{{OPEN_ISSUES}}
+
+Recent Closed Issues:
+{{RECENT_CLOSED_ISSUES}}

--- a/.github/workflows/daily-plan-issue.yml
+++ b/.github/workflows/daily-plan-issue.yml
@@ -1,0 +1,45 @@
+name: Daily Plan Issue
+
+"on":
+  schedule:
+    - cron: "0 22 * * *"
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: "Issue を作らず本文だけ確認する"
+        required: false
+        default: true
+        type: boolean
+      plan_date:
+        description: "タイトルに使う日付 (YYYY-MM-DD)"
+        required: false
+        type: string
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  create-daily-plan-issue:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+
+      - name: Install Copilot CLI
+        run: npm install --global @github/copilot@1.0.32
+
+      - name: Generate daily plan issue
+        run: node scripts/create-daily-plan-issue.mjs
+        env:
+          REPOSITORY: ${{ github.repository }}
+          PLAN_DATE: ${{ inputs.plan_date }}
+          DRY_RUN: ${{ inputs.dry_run }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          COPILOT_GITHUB_TOKEN: ${{ secrets.COPILOT_CLI_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -22,3 +22,23 @@
 - ai agents instructions　Skills など作成されていること
 - 失敗、成果、などをナレッジ蓄積し、workspacesが成長できること
 - 最新の技術を取り入れられていること
+
+## 日次 plan issue 自動化
+
+- workflow: `.github/workflows/daily-plan-issue.yml`
+- 実行タイミング: 毎日 07:00 JST と `workflow_dispatch`
+- 生成内容: Copilot CLI が `PLAN.md`、`README.md`、open / recent issues を元に、その日の plan issue 本文を日本語で生成
+- issue タイトル: `日次プラン提案 YYYY-MM-DD`
+- 重複防止: 同日の open issue があれば新規起票をスキップ
+
+必要な secret:
+
+- `COPILOT_CLI_TOKEN`
+  - fine-grained PAT を作成し、`Copilot Requests` 権限を付与する
+  - issue の作成自体は workflow 標準の `GITHUB_TOKEN` を使う
+
+手動確認方法:
+
+- Actions から `Daily Plan Issue` を実行する
+- `dry_run` を `true` にすると、issue は作らず本文だけをログに出す
+- `plan_date` を指定すると、その日付のタイトルで重複判定する

--- a/scripts/create-daily-plan-issue.mjs
+++ b/scripts/create-daily-plan-issue.mjs
@@ -1,0 +1,197 @@
+import { execFileSync } from "node:child_process";
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+
+const repository = process.env.REPOSITORY ?? process.env.GITHUB_REPOSITORY;
+
+if (!repository) {
+  throw new Error("REPOSITORY or GITHUB_REPOSITORY is required.");
+}
+
+const planDate = resolvePlanDate(process.env.PLAN_DATE);
+const dryRun = toBoolean(process.env.DRY_RUN);
+const title = `日次プラン提案 ${planDate}`;
+
+const openIssues = listIssues("open", 20);
+const recentClosedIssues = listIssues("closed", 10);
+const existingIssue = openIssues.find((issue) => issue.title === title);
+
+if (existingIssue) {
+  console.log(`Skipped: ${existingIssue.url}`);
+  process.exit(0);
+}
+
+const prompt = buildPrompt({
+  repository,
+  planDate,
+  openIssues,
+  recentClosedIssues
+});
+
+const generatedBody = normalizeGeneratedBody(generateIssueBody(prompt));
+const issueBody = [
+  "## 自動生成メモ",
+  `- 実行日: ${planDate}`,
+  "- 生成元: GitHub Actions / Daily Plan Issue",
+  "- 注意: 自動提案なので、採用前に内容を確認してください。",
+  "",
+  generatedBody
+].join("\n");
+
+if (dryRun) {
+  console.log(title);
+  console.log("");
+  console.log(issueBody);
+  process.exit(0);
+}
+
+const tempDir = mkdtempSync(path.join(tmpdir(), "daily-plan-issue-"));
+const bodyPath = path.join(tempDir, "issue-body.md");
+
+try {
+  writeFileSync(bodyPath, issueBody, "utf8");
+  const issueUrl = runCommand("gh", [
+    "issue",
+    "create",
+    "--repo",
+    repository,
+    "--title",
+    title,
+    "--body-file",
+    bodyPath,
+    "--label",
+    "plan-first"
+  ]);
+
+  console.log(`Created: ${issueUrl}`);
+} finally {
+  rmSync(tempDir, { recursive: true, force: true });
+}
+
+function buildPrompt({ repository: currentRepository, planDate: currentPlanDate, openIssues: currentOpenIssues, recentClosedIssues: currentClosedIssues }) {
+  const promptTemplate = readWorkspaceFile(".github/prompts/daily-plan-issue.prompt.md");
+
+  return promptTemplate
+    .replaceAll("{{PLAN_DATE}}", currentPlanDate)
+    .replaceAll("{{REPOSITORY}}", currentRepository)
+    .replaceAll("{{README_CONTENT}}", readWorkspaceFile("README.md"))
+    .replaceAll("{{PLAN_CONTENT}}", readWorkspaceFile("PLAN.md"))
+    .replaceAll("{{COPILOT_INSTRUCTIONS}}", readWorkspaceFile(".github/copilot-instructions.md"))
+    .replaceAll("{{OPEN_ISSUES}}", JSON.stringify(currentOpenIssues, null, 2))
+    .replaceAll("{{RECENT_CLOSED_ISSUES}}", JSON.stringify(currentClosedIssues, null, 2));
+}
+
+function generateIssueBody(prompt) {
+  if (process.env.MOCK_COPILOT_RESPONSE) {
+    return process.env.MOCK_COPILOT_RESPONSE;
+  }
+
+  if (!process.env.COPILOT_GITHUB_TOKEN) {
+    throw new Error(
+      "COPILOT_GITHUB_TOKEN is required. Add the COPILOT_CLI_TOKEN repository secret with the Copilot Requests permission."
+    );
+  }
+
+  const argumentsList = [
+    "-p",
+    prompt,
+    "--silent",
+    "--no-ask-user",
+    "--allow-all-tools",
+    "--disable-builtin-mcps",
+    "--deny-tool=shell",
+    "--deny-tool=write",
+    "--no-custom-instructions"
+  ];
+
+  const model = process.env.COPILOT_MODEL?.trim();
+
+  if (model) {
+    argumentsList.push("--model", model);
+  }
+
+  return runCommand("copilot", argumentsList, {
+    env: {
+      ...process.env,
+      COPILOT_GITHUB_TOKEN: process.env.COPILOT_GITHUB_TOKEN
+    }
+  });
+}
+
+function listIssues(state, limit) {
+  const raw = runCommand("gh", [
+    "issue",
+    "list",
+    "--repo",
+    repository,
+    "--state",
+    state,
+    "--limit",
+    String(limit),
+    "--json",
+    "number,title,body,labels,url"
+  ]);
+
+  return JSON.parse(raw).map((issue) => ({
+    number: issue.number,
+    title: issue.title,
+    body: compactText(issue.body),
+    labels: issue.labels.map((label) => label.name),
+    url: issue.url
+  }));
+}
+
+function runCommand(command, args, options = {}) {
+  return execFileSync(command, args, {
+    encoding: "utf8",
+    maxBuffer: 10 * 1024 * 1024,
+    stdio: ["ignore", "pipe", "pipe"],
+    ...options
+  }).trim();
+}
+
+function readWorkspaceFile(relativePath) {
+  return readFileSync(path.join(process.cwd(), relativePath), "utf8").trim();
+}
+
+function resolvePlanDate(value) {
+  if (value && /^\d{4}-\d{2}-\d{2}$/.test(value)) {
+    return value;
+  }
+
+  return new Intl.DateTimeFormat("en-CA", {
+    timeZone: "Asia/Tokyo",
+    year: "numeric",
+    month: "2-digit",
+    day: "2-digit"
+  }).format(new Date());
+}
+
+function normalizeGeneratedBody(value) {
+  const trimmed = value.trim();
+  const withoutFence = trimmed
+    .replace(/^```(?:markdown)?\s*/i, "")
+    .replace(/\s*```$/i, "")
+    .trim();
+
+  if (!withoutFence) {
+    throw new Error("Copilot CLI returned an empty issue body.");
+  }
+
+  return withoutFence;
+}
+
+function compactText(value) {
+  const singleLine = value.replace(/\s+/g, " ").trim();
+
+  if (singleLine.length <= 240) {
+    return singleLine;
+  }
+
+  return `${singleLine.slice(0, 237)}...`;
+}
+
+function toBoolean(value) {
+  return /^(1|true|yes)$/i.test(value ?? "");
+}


### PR DESCRIPTION
## 概要
- GitHub Actions で毎日 1 回と手動実行に対応した日次 plan issue workflow を追加
- Copilot CLI 用の prompt テンプレートと issue 作成スクリプトを追加
- 同日タイトルの open issue があれば重複起票しないようにした
- README に secret と手動確認手順を追記

## 注意点
- Copilot CLI 実行には fine-grained PAT の `Copilot Requests` 権限を持つ `COPILOT_CLI_TOKEN` secret が必要
- issue の作成には workflow 標準の `GITHUB_TOKEN` を利用

## テスト
- `node --check scripts/create-daily-plan-issue.mjs`
- `DRY_RUN=true MOCK_COPILOT_RESPONSE=... node scripts/create-daily-plan-issue.mjs`
- secret 未設定時に明示的なエラーメッセージを確認

Closes #7