### PR TITLE
GitHub Pages 配下の遷移と 404 フォールバックを修正

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,44 @@ flowchart TD
 | build / test | 壊れていないかを継続的に確認しやすくする |
 | E2E レポート導線 | `/report` から Playwright レポートへ移動できる |
 
+## 公開とデプロイ
+
+このサイトは GitHub Pages に公開します。
+
+- main に push されると GitHub Actions の deploy workflow が起動します
+- workflow は依存関係のインストール、build、Pages artifact の upload、GitHub Pages への deploy を順に実行します
+- 想定公開 URL は https://cocomomojo.github.io/test_ai1/ です
+- アプリの router とレポートリンクも base path に追従するため、公開環境では `/test_ai1/` 配下で遷移します
+
+### https://cocomomojo.github.io が 404 の場合
+
+これは異常とは限りません。
+この repo は test_ai1 という名前の project Pages 用 repo なので、公開先は通常 https://cocomomojo.github.io/test_ai1/ になります。
+
+https://cocomomojo.github.io のルート直下で公開したい場合は、次のどちらかが必要です。
+
+- repo 名を cocomomojo.github.io にした user Pages 用 repo を使う
+- 独自ドメインを設定する
+
+### 公開 URL も 404 の場合の確認
+
+- GitHub Actions の Deploy to GitHub Pages workflow が成功しているか確認する
+- repository Settings の Pages が GitHub Actions を使う設定になっているか確認する
+- main への push 後の最新 deploy が完了しているか確認する
+
+### 画面を直接開いたり再読込したときだけ 404 の場合
+
+GitHub Pages は SPA の履歴ルーティングを自動では復元しません。
+この repo では build 時に `dist/index.html` を `dist/404.html` としても出力し、子 URL を直接開いた場合でも同じ app shell が読み込まれるようにしています。
+
+- 例: `https://cocomomojo.github.io/test_ai1/hobbies/running` を直接開いても、GitHub Pages が `404.html` を返し、その中身で React アプリが起動します
+- その後の画面判定は router が行うため、既知の route なら該当ページ、未知の route ならアプリ内の 404 画面を表示します
+- それでも表示されない場合は deploy artifact に `404.html` が含まれているか確認してください
+
+> [!NOTE]
+> 以前の実装では router が GitHub Pages の base path を見ていなかったため、404 画面の `Return home` から `https://cocomomojo.github.io/` に戻ることがありました。  
+> 現在は router 側でも base path を参照するため、`https://cocomomojo.github.io/test_ai1/` 配下へ戻る動作に揃えています。
+
 ## 日次 plan issue って何？ 📅
 
 **「今日は何を直す・進めるか」を毎日提案してくれるメモの自動作成機能**です。

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "scripts": {
     "dev": "vite",
-    "build": "tsc -b && vite build",
+    "build": "tsc -b && vite build && node scripts/create-github-pages-fallback.mjs",
     "preview": "vite preview",
     "lint": "eslint .",
     "test": "vitest run",

--- a/scripts/create-github-pages-fallback.mjs
+++ b/scripts/create-github-pages-fallback.mjs
@@ -1,0 +1,11 @@
+import { copyFile } from "node:fs/promises";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const currentFilePath = fileURLToPath(import.meta.url);
+const currentDirectoryPath = path.dirname(currentFilePath);
+const distDirectoryPath = path.resolve(currentDirectoryPath, "..", "dist");
+const indexHtmlPath = path.join(distDirectoryPath, "index.html");
+const fallbackHtmlPath = path.join(distDirectoryPath, "404.html");
+
+await copyFile(indexHtmlPath, fallbackHtmlPath);

--- a/src/app/basePath.test.ts
+++ b/src/app/basePath.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from "vitest";
+
+import { normalizeRouterBasename, resolveBasePath } from "./basePath";
+
+describe("normalizeRouterBasename", () => {
+  it("keeps the root path unchanged", () => {
+    expect(normalizeRouterBasename("/")).toBe("/");
+  });
+
+  it("removes the trailing slash for project pages", () => {
+    expect(normalizeRouterBasename("/test_ai1/")).toBe("/test_ai1");
+  });
+});
+
+describe("resolveBasePath", () => {
+  it("builds a root-based static asset path", () => {
+    expect(resolveBasePath("/", "playwright-report/index.html")).toBe(
+      "/playwright-report/index.html"
+    );
+  });
+
+  it("builds a project pages static asset path", () => {
+    expect(resolveBasePath("/test_ai1/", "playwright-report/index.html")).toBe(
+      "/test_ai1/playwright-report/index.html"
+    );
+  });
+});

--- a/src/app/basePath.ts
+++ b/src/app/basePath.ts
@@ -1,0 +1,19 @@
+export function normalizeRouterBasename(baseUrl: string) {
+  if (!baseUrl || baseUrl === "/") {
+    return "/";
+  }
+
+  return baseUrl.endsWith("/") ? baseUrl.slice(0, -1) : baseUrl;
+}
+
+export function resolveBasePath(baseUrl: string, targetPath: string) {
+  const normalizedBaseUrl =
+    !baseUrl || baseUrl === "/"
+      ? "/"
+      : baseUrl.endsWith("/")
+        ? baseUrl
+        : `${baseUrl}/`;
+  const normalizedTargetPath = targetPath.startsWith("/") ? targetPath.slice(1) : targetPath;
+
+  return `${normalizedBaseUrl}${normalizedTargetPath}`;
+}

--- a/src/app/router.tsx
+++ b/src/app/router.tsx
@@ -1,5 +1,6 @@
 import { createBrowserRouter } from "react-router-dom";
 
+import { normalizeRouterBasename } from "./basePath";
 import { AppLayout } from "./AppLayout";
 import { HobbyDetailPage } from "../pages/HobbyDetailPage";
 import { HobbiesPage } from "../pages/HobbiesPage";
@@ -7,28 +8,33 @@ import { HomePage } from "../pages/HomePage";
 import { NotFoundPage } from "../pages/NotFoundPage";
 import { TestReportPage } from "../pages/TestReportPage";
 
-export const appRouter = createBrowserRouter([
+export const appRouter = createBrowserRouter(
+  [
+    {
+      path: "/",
+      element: <AppLayout />,
+      errorElement: <NotFoundPage />,
+      children: [
+        {
+          index: true,
+          element: <HomePage />
+        },
+        {
+          path: "hobbies",
+          element: <HobbiesPage />
+        },
+        {
+          path: "hobbies/:slug",
+          element: <HobbyDetailPage />
+        },
+        {
+          path: "report",
+          element: <TestReportPage />
+        }
+      ]
+    }
+  ],
   {
-    path: "/",
-    element: <AppLayout />,
-    errorElement: <NotFoundPage />,
-    children: [
-      {
-        index: true,
-        element: <HomePage />
-      },
-      {
-        path: "hobbies",
-        element: <HobbiesPage />
-      },
-      {
-        path: "hobbies/:slug",
-        element: <HobbyDetailPage />
-      },
-      {
-        path: "report",
-        element: <TestReportPage />
-      }
-    ]
+    basename: normalizeRouterBasename(import.meta.env.BASE_URL)
   }
-]);
+);

--- a/src/pages/TestReportPage.test.tsx
+++ b/src/pages/TestReportPage.test.tsx
@@ -1,6 +1,7 @@
 import { render, screen } from "@testing-library/react";
 import { MemoryRouter } from "react-router-dom";
 
+import { resolveBasePath } from "../app/basePath";
 import { TestReportPage } from "../pages/TestReportPage";
 
 describe("TestReportPage", () => {
@@ -23,6 +24,9 @@ describe("TestReportPage", () => {
     );
 
     const link = screen.getByRole("link", { name: "最新のテストレポートを開く" });
-    expect(link).toHaveAttribute("href", "/playwright-report/index.html");
+    expect(link).toHaveAttribute(
+      "href",
+      resolveBasePath(import.meta.env.BASE_URL, "playwright-report/index.html")
+    );
   });
 });

--- a/src/pages/TestReportPage.tsx
+++ b/src/pages/TestReportPage.tsx
@@ -1,4 +1,8 @@
+import { resolveBasePath } from "../app/basePath";
+
 export function TestReportPage() {
+  const reportHref = resolveBasePath(import.meta.env.BASE_URL, "playwright-report/index.html");
+
   return (
     <section className="space-y-6">
       <div className="space-y-2">
@@ -24,7 +28,7 @@ export function TestReportPage() {
           </div>
 
           <a
-            href="/playwright-report/index.html"
+            href={reportHref}
             className="inline-flex items-center gap-2 rounded-full bg-slate-950 px-5 py-3 text-sm font-semibold text-white transition hover:bg-slate-800"
           >
             最新のテストレポートを開く


### PR DESCRIPTION
## 概要
GitHub Pages の project Pages 配下で発生していた遷移ずれと、子 URL の直接アクセス時の 404 を修正します。

## 変更内容
- router が `import.meta.env.BASE_URL` を basename として使うよう修正
- Playwright レポートリンクを base path 対応に変更
- build 後に `dist/404.html` を生成して GitHub Pages の SPA フォールバックを追加
- README に公開 URL、404 の切り分け、現在の挙動を追記

## 確認
- `npm run test`
- `npm run build`
- `npm run test:e2e`